### PR TITLE
safe to leak NodeIndex defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "orx-selfref-col"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`SelfRefCol` is a core data structure to conveniently build safe and efficient self referential collections, such as linked lists and trees."
 license = "MIT"
 repository = "https://github.com/orxfun/orx-selfref-col/"
-keywords = ["self-referential", "collection", "recursive", "list", "tree"]
+keywords = ["self-referential", "list", "tree", "recursive", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-split-vec = "2.0"
+orx-split-vec = "2.1"
 
 [dev-dependencies]
 test-case = "3.3"

--- a/src/common_traits/from_iter.rs
+++ b/src/common_traits/from_iter.rs
@@ -1,6 +1,5 @@
-use orx_split_vec::prelude::PinnedVec;
-
 use crate::{Node, SelfRefCol, Variant};
+use orx_split_vec::prelude::PinnedVec;
 
 impl<'a, V, T, P> FromIterator<T> for SelfRefCol<'a, V, T, P>
 where
@@ -14,6 +13,7 @@ where
             ends: V::Ends::default(),
             len: pinned_vec.len(),
             pinned_vec,
+            memory_reclaim_policy: Default::default(),
             phantom: Default::default(),
         }
     }
@@ -24,7 +24,7 @@ mod tests {
     use crate::*;
     use orx_split_vec::{prelude::PinnedVec, Recursive, SplitVec};
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, String> for Var {
         type Storage = NodeDataLazyClose<String>;

--- a/src/data/eager_close.rs
+++ b/src/data/eager_close.rs
@@ -17,6 +17,11 @@ impl<T> NodeData<T> for NodeDataEagerClose<T> {
     }
 
     #[inline(always)]
+    fn is_active(&self) -> bool {
+        true
+    }
+
+    #[inline(always)]
     fn get_mut(&mut self) -> Option<&mut T> {
         Some(&mut self.0)
     }
@@ -57,6 +62,12 @@ mod tests {
     fn get() {
         let data = NodeDataEagerClose::active(42);
         assert_eq!(Some(&42), data.get());
+    }
+
+    #[test]
+    fn is_active() {
+        let data = NodeDataEagerClose::active(42);
+        assert!(data.is_active());
     }
 
     #[test]

--- a/src/data/lazy_close.rs
+++ b/src/data/lazy_close.rs
@@ -17,6 +17,11 @@ impl<T> NodeData<T> for NodeDataLazyClose<T> {
     }
 
     #[inline(always)]
+    fn is_active(&self) -> bool {
+        self.0.is_some()
+    }
+
+    #[inline(always)]
     fn get_mut(&mut self) -> Option<&mut T> {
         self.0.as_mut()
     }

--- a/src/data/node_data.rs
+++ b/src/data/node_data.rs
@@ -3,6 +3,9 @@ pub trait NodeData<T> {
     /// Creates a new active node data with the given `value`.
     fn active(value: T) -> Self;
 
+    /// Returns whether the storage is active, or closed otherwise.
+    fn is_active(&self) -> bool;
+
     /// Returns a reference to the stored value; returns None if the node is not active.
     fn get(&self) -> Option<&T>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@
 //! ```rust
 //! use orx_selfref_col::*;
 //!
+//! #[derive(Clone, Copy)]
 //! struct SinglyListVariant;
 //!
 //! impl<'a, T: 'a> Variant<'a, T> for SinglyListVariant {
@@ -115,6 +116,7 @@
 //!     type Ends = NodeRefSingle<'a, Self, T>; // there is only one end, namely the front of the list
 //! }
 //!
+//! #[derive(Clone, Copy)]
 //! struct DoublyListVariant;
 //!
 //! impl<'a, T: 'a> Variant<'a, T> for DoublyListVariant {
@@ -125,6 +127,7 @@
 //!     type Ends = NodeRefsArray<'a, 2, Self, T>; // there are two ends, namely the front and back of the list
 //! }
 //!
+//! #[derive(Clone, Copy)]
 //! struct BinaryTreeVariant;
 //!
 //! impl<'a, T: 'a> Variant<'a, T> for BinaryTreeVariant {
@@ -135,6 +138,7 @@
 //!     type Ends = NodeRefSingle<'a, Self, T>; // there is only one end, namely the root of the tree
 //! }
 //!
+//! #[derive(Clone, Copy)]
 //! struct DynamicTreeVariant;
 //!
 //! impl<'a, T: 'a> Variant<'a, T> for DynamicTreeVariant {
@@ -179,7 +183,7 @@ mod variants;
 pub use data::{
     eager_close::NodeDataEagerClose, lazy_close::NodeDataLazyClose, node_data::NodeData,
 };
-pub use nodes::node::Node;
+pub use nodes::{can_leak::CanLeak, index::NodeIndex, node::Node};
 pub use references::{
     array::NodeRefsArray, node_refs::NodeRefs, none::NodeRefNone, single::NodeRefSingle,
     vec::NodeRefsVec,

--- a/src/memory_reclaim/lazy_unidirectional.rs
+++ b/src/memory_reclaim/lazy_unidirectional.rs
@@ -12,6 +12,7 @@ pub(crate) fn reclaim_closed_nodes<'rf, 'a, T: 'a, V, P>(
 {
     if !vec_mut.col.pinned_vec.is_empty() {
         reorganize_nodes(vec_mut);
+        vec_mut.col.memory_reclaimed();
 
         let len = vec_mut.col.len;
         vec_mut.col.pinned_vec.truncate(len);
@@ -112,7 +113,7 @@ mod tests {
     use crate::{MemoryReclaimNever, NodeDataLazyClose, NodeRefSingle, NodeRefsArray, SelfRefCol};
     use test_case::test_case;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, String> for Var {
         type Storage = NodeDataLazyClose<String>;
@@ -123,22 +124,22 @@ mod tests {
     }
 
     fn new_full_vec<'a>(n: usize) -> SelfRefCol<'a, Var, String> {
-        let mut vec = SelfRefCol::<Var, _>::new();
+        let mut col = SelfRefCol::<Var, _>::new();
 
         let values: Vec<_> = (0..n).map(|x| x.to_string()).collect();
-        vec.move_mutate(values, |x, values| {
+        col.mutate(values, |x, values| {
             for val in values {
                 _ = x.push_get_ref(val);
             }
         });
 
-        vec
+        col
     }
 
     fn new_vec<'a>(n: usize, vacant_indices: Vec<usize>) -> SelfRefCol<'a, Var, String> {
-        let mut vec = new_full_vec(n);
+        let mut col = new_full_vec(n);
 
-        vec.move_mutate(vacant_indices, |x, vacant_indices| {
+        col.mutate(vacant_indices, |x, vacant_indices| {
             for i in vacant_indices {
                 let node = &mut x.col.pinned_vec[i];
                 let _ = node.data.close();
@@ -146,14 +147,14 @@ mod tests {
             }
         });
 
-        vec
+        col
     }
 
-    fn num_occupied(vec: &SelfRefCol<Var, String>) -> usize {
-        vec.pinned_vec.iter().filter(|x| x.is_active()).count()
+    fn num_occupied(col: &SelfRefCol<Var, String>) -> usize {
+        col.pinned_vec.iter().filter(|x| x.is_active()).count()
     }
-    fn num_vacant(vec: &SelfRefCol<Var, String>) -> usize {
-        vec.pinned_vec.iter().filter(|x| x.is_closed()).count()
+    fn num_vacant(col: &SelfRefCol<Var, String>) -> usize {
+        col.pinned_vec.iter().filter(|x| x.is_closed()).count()
     }
 
     #[test_case(1)]
@@ -164,16 +165,16 @@ mod tests {
     #[test_case(987)]
     #[test_case(3254)]
     fn when_full(n: usize) {
-        let mut vec = new_full_vec(n);
+        let mut col = new_full_vec(n);
 
-        assert_eq!(num_occupied(&vec), n);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n);
+        assert_eq!(num_vacant(&col), 0);
 
-        let mut x = SelfRefColMut::new(&mut vec);
+        let mut x = SelfRefColMut::new(&mut col);
         reclaim_closed_nodes(&mut x);
 
-        assert_eq!(num_occupied(&vec), n);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n);
+        assert_eq!(num_vacant(&col), 0);
     }
 
     #[test_case(1)]
@@ -184,16 +185,16 @@ mod tests {
     #[test_case(987)]
     #[test_case(3254)]
     fn when_one_vacant_at_end(n: usize) {
-        let mut vec = new_vec(n, vec![n - 1]);
+        let mut col = new_vec(n, vec![n - 1]);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 1);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 1);
 
-        let mut x = SelfRefColMut::new(&mut vec);
+        let mut x = SelfRefColMut::new(&mut col);
         reclaim_closed_nodes(&mut x);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 0);
     }
 
     #[test_case(1)]
@@ -204,16 +205,16 @@ mod tests {
     #[test_case(987)]
     #[test_case(3254)]
     fn when_one_vacant_in_middle(n: usize) {
-        let mut vec = new_vec(n, vec![n / 2]);
+        let mut col = new_vec(n, vec![n / 2]);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 1);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 1);
 
-        let mut x = SelfRefColMut::new(&mut vec);
+        let mut x = SelfRefColMut::new(&mut col);
         reclaim_closed_nodes(&mut x);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 0);
     }
 
     #[test_case(1)]
@@ -224,16 +225,16 @@ mod tests {
     #[test_case(987)]
     #[test_case(3254)]
     fn when_one_vacant_at_start(n: usize) {
-        let mut vec = new_vec(n, vec![0]);
+        let mut col = new_vec(n, vec![0]);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 1);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 1);
 
-        let mut x = SelfRefColMut::new(&mut vec);
+        let mut x = SelfRefColMut::new(&mut col);
         reclaim_closed_nodes(&mut x);
 
-        assert_eq!(num_occupied(&vec), n - 1);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n - 1);
+        assert_eq!(num_vacant(&col), 0);
     }
 
     #[test_case(0)]
@@ -247,15 +248,15 @@ mod tests {
     fn when_half_is_closed(n: usize) {
         let dropped_indices: Vec<_> = (0..n).filter(|x| x % 2 == 0).collect();
         let num_dropped = dropped_indices.len();
-        let mut vec = new_vec(n, dropped_indices);
+        let mut col = new_vec(n, dropped_indices);
 
-        assert_eq!(num_occupied(&vec), n - num_dropped);
-        assert_eq!(num_vacant(&vec), num_dropped);
+        assert_eq!(num_occupied(&col), n - num_dropped);
+        assert_eq!(num_vacant(&col), num_dropped);
 
-        let mut x = SelfRefColMut::new(&mut vec);
+        let mut x = SelfRefColMut::new(&mut col);
         reclaim_closed_nodes(&mut x);
 
-        assert_eq!(num_occupied(&vec), n - num_dropped);
-        assert_eq!(num_vacant(&vec), 0);
+        assert_eq!(num_occupied(&col), n - num_dropped);
+        assert_eq!(num_vacant(&col), 0);
     }
 }

--- a/src/memory_reclaim/memory_state.rs
+++ b/src/memory_reclaim/memory_state.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemoryState {
+    pub id: usize,
+}
+
+impl MemoryState {
+    pub const fn new() -> Self {
+        Self { id: 0 }
+    }
+
+    pub fn successor_state(&self) -> Self {
+        Self { id: self.id + 1 }
+    }
+}
+
+impl Default for MemoryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/memory_reclaim/mod.rs
+++ b/src/memory_reclaim/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod lazy_bidirectional;
 pub(crate) mod lazy_unidirectional;
+pub(crate) mod memory_state;
 pub(crate) mod utilization;

--- a/src/nodes/can_leak.rs
+++ b/src/nodes/can_leak.rs
@@ -1,0 +1,76 @@
+use crate::{nodes::index::NodeIndex, Node, Variant};
+use orx_split_vec::prelude::PinnedVec;
+
+/// Marker trait for types which are safe to leak out of the `SelfRefCol`.
+/// In other words, the mutation methods of the collection can only return types implementing `CanLeak`.
+///
+/// For a given self referential collection `SelfRefCol<'a, V, T, P>`, the following types implement `CanLeak`:
+/// * `T` -> values can be taken out of the collection and returned,
+/// * `NodeIndex<'a, V, T>` -> a safe reference to the collection can be returned and used with safety checks to access nodes in constant time.
+///
+/// On the other hand, neither `Node<'a, V, T>` nor `&Node<'a, V, T>` implements `CanLeak`.
+/// Therefore, the nodes and inter-node references cannot leak, they are safely and completely encapsulated inside the `SelfRefCol`.
+pub trait CanLeak<'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+// T
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for T
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for Option<T>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for Vec<T>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for [T; N]
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+// NodeIndex
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for NodeIndex<'a, V, T>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for Option<NodeIndex<'a, V, T>>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, V, T, P> CanLeak<'a, V, T, P> for Vec<NodeIndex<'a, V, T>>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}
+
+impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for [NodeIndex<'a, V, T>; N]
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+}

--- a/src/nodes/index.rs
+++ b/src/nodes/index.rs
@@ -1,0 +1,507 @@
+use crate::{
+    variants::memory_reclaim::MemoryReclaimPolicy, Node, SelfRefCol, SelfRefColMut, Variant,
+};
+use orx_split_vec::prelude::PinnedVec;
+
+/// An index to a node in a `SelfRefCol` providing ***O(1)*** access time to the corresponding node.
+///
+/// It can be considered as a reference to a node which is safe to leak outside the collection.
+/// * This is analogous to the `usize` index of an element of a standard vector which can be stored independently of the vector as a value.
+/// * However, `NodeIndex` provides additional safety and correctness guarantees since validity of references is of utmost importance for self referential collections.
+///
+/// An index can be obtained from mutation methods of `SelfRefCol` which conventionally contain `take` in its name, such as `mutate_take` or `mutate_take`.
+/// Furthermore, the index can be stored completely independently of the collection as a value.
+///
+/// However, when a node index is used to access the node of the collection, its correctness is guaranteed (see the Safety section for details).
+/// When in doubt, `is_valid_for_collection` method can be used.
+///
+/// # Safety
+///
+/// * when `self.is_valid_for_collection(collection)` returns true; the node index can be converted into a valid node reference.
+/// * when `self.is_valid_for_collection(collection)` returns false; the conversion to a node reference correctly returns None, this might lead to a panic depending on how the reference is used.
+///
+/// Invalid node index can be observed if at least one of the following three cases is observed.
+/// 1. If the `NodeIndex` is created for another collection.
+/// 2. If node which returned this `NodeIndex` on insertion is removed from the `collection`.
+/// 3. If positions of the nodes were reorganized in order to optimize memory usage, which most likely invalidated this index.
+///
+/// ## 1. `NodeIndex` created for another collection
+///
+/// This requirement straightforward. Consider the corresponding demonstration with a standard vector, where index of an element is analogous to `NodeIndex` here.
+///
+/// ```rust
+/// let mut vec = vec![];
+///
+/// vec.push('a');
+/// vec.push('b');
+/// let index_x = {
+///     vec.push('x');
+///     vec.len() - 1
+/// };
+/// vec.push('c');
+///
+/// // Case 1
+/// let node_x = vec.get(index_x);
+/// assert_eq!(node_x, Some(&'x')); // ✓ index used on the correct collection and returned the correct value
+///
+/// // Case 2
+/// let vec2 = vec!['0', '1', '2', '3'];
+/// let node_x = vec2.get(index_x);
+/// assert_eq!(node_x, Some(&'2')); // 🗙 index used on wrong collection, and obtained a wrong value
+///
+/// // Case 3
+/// let vec3 = vec!['.'];
+/// let node_x = vec3.get(index_x);
+/// assert!(node_x.is_none()); // 🗙 index used on wrong collection, obtained None, although for a different reason
+/// ```
+///
+/// While using `NodeIndex` in a `SelfRefCol`:
+/// * in Case 1: we receive a valid reference to the correct node,
+/// * in Case 2: we receive `None`, unlike the behavior above for vec,
+/// * in Case 3: we receive `None` again.
+///
+/// Note that the way Case 2 is handled provides additional safety.
+/// This safety is achieved with additional memory and computational cost compared to usize & Vec example.
+/// However, this makes sense considering that the primary feature of self referential collections is
+/// efficiency in following the references rather than accessing by indices.
+///
+/// ## 2. Node for which `NodeIndex` is removed from the collection
+///
+/// This requirement as well is straightforward, and below is the demonstration using the standard vector & index analogy.
+///
+/// ```rust
+/// let mut vec = vec![];
+///
+/// vec.push('a');
+/// vec.push('b');
+/// let index_x = {
+///     vec.push('x');
+///     vec.len() - 1
+/// };
+/// vec.push('c');
+///
+/// // Case 4
+/// vec.remove(2); // at this point, vec = ['a', 'b', 'c']
+/// let node_x = vec.get(index_x);
+/// assert_eq!(node_x, Some(&'c')); // 🗙 index used after node 'x' is removed from the collection, and grabbed a wrong value
+/// ```
+///
+/// While using `NodeIndex` to access a `SelfRefCol` in Case 4, we would again receive None.
+/// Similar to above, this is an additional correctness check.
+///
+/// ## 3. If node positions of the collection are reorganized
+///
+/// Note that such node reorganization is observed when memory reclaim policy of the collection is `MemoryReclaimOnThreshold`.
+/// It will never be observed when `MemoryReclaimNever` is used.
+/// This leads to the following rule of thumb:
+/// * If amount of removals from our self referential collection is not high compared to the size of the collection,
+/// it is beneficial to use `MemoryReclaimNever`. This has two advantages:
+///   * Our collection will never spend time for reorganization.
+/// However, the benefit here can be considered to be minor since memory checks are triggered only on removals which are rare in this case.
+///   * More importantly, this third invalid node index case can never be observed. This leads to the following advantages:
+///     * `NodeIndex` is as small as a pointer or `usize`. This is the minimum index size that can be achieved.
+///     * Accessing through the `NodeIndex` skips this third validity check, which precisely an equality check of two 128-bit values.
+/// * For all other cases where our collection continuously grows and shrinks, or when we do not require access by `NodeIndex`,
+/// it is beneficial to use `MemoryReclaimOnThreshold`.
+///
+/// See below for a demonstration of the analogous situation in vector & index case.
+///
+/// ```rust
+/// let mut vec = vec![];
+///
+/// vec.push('a');
+/// vec.push('b');
+/// let index_x = {
+///     vec.push('x');
+///     vec.len() - 1
+/// };
+/// vec.push('c');
+///
+/// // Case 5
+/// vec.remove(0); // at this point, vec = ['b', 'x', 'c']
+/// let node_x = vec.get(index_x);
+/// assert_eq!(node_x, Some(&'c')); // 🗙 index used after nodes are reorganized changing location of 'x', and we grabbed a wrong value
+/// ```
+///
+/// As above, when using a `NodeIndex` on a `SelfRefCol`, we would receive `None` for Case 5, rather than getting a reference to a wrong node.
+#[derive(Copy)]
+pub struct NodeIndex<'a, V, T>
+where
+    V: Variant<'a, T>,
+{
+    collection_key: V::MemoryReclaim,
+    pub(crate) node_key: &'a Node<'a, V, T>,
+}
+
+impl<'a, V, T> Clone for NodeIndex<'a, V, T>
+where
+    V: Variant<'a, T>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            collection_key: self.collection_key,
+            node_key: self.node_key,
+        }
+    }
+}
+
+impl<'a, V, T> PartialEq for NodeIndex<'a, V, T>
+where
+    V: Variant<'a, T>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.collection_key
+            .is_same_collection_as(&other.collection_key)
+            && self.node_key.ref_eq(other.node_key)
+    }
+}
+impl<'a, V, T> Eq for NodeIndex<'a, V, T> where V: Variant<'a, T> {}
+
+impl<'a, V, T> NodeIndex<'a, V, T>
+where
+    V: Variant<'a, T>,
+{
+    /// Creates a new node index with the given `collection_key` and `node_key`.
+    ///
+    /// * `node_key` is always a pointer size, a reference to the node at the point when the index is created;
+    /// * `collection_key` is:
+    ///   * zero-sized when the collection uses `MemoryReclaimNever` as its `MemoryReclaimPolicy` because in this case:
+    ///     * a wrong collection case is caught by pinned collection's `contains_reference` test,
+    ///     * a removed node case is caught by checking whether or not the node is active, and finally
+    ///     * a reorganized memory positions case can never be observed.
+    ///   * 128-bit sized when the collection uses `MemoryReclaimOnThreshold` as its `MemoryReclaimPolicy`:
+    ///     * the first and second cases caught identically; however,
+    ///     * the third case is caught by a uuid comparison.
+    pub(crate) fn new(collection_key: V::MemoryReclaim, node_key: &'a Node<'a, V, T>) -> Self {
+        Self {
+            collection_key,
+            node_key,
+        }
+    }
+
+    /// Returns true only if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    ///
+    /// This conditions are sufficient to prove that the node index is valid and safe to use and will access the correct node.
+    pub fn is_valid_for_collection<P>(&self, collection: &SelfRefCol<'a, V, T, P>) -> bool
+    where
+        P: PinnedVec<Node<'a, V, T>>,
+    {
+        self.collection_key
+            .is_same_collection_as(&collection.memory_reclaim_policy)
+            && collection.pinned_vec.contains_reference(self.node_key)
+            && self.node_key.is_active()
+    }
+
+    /// Converts the node index to a reference to the node in the `collection`; returns None if `self.is_valid_for_collection(collection)` is false.
+    ///
+    /// `is_valid_for_collection(collection)` returns true if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub fn get_ref<'rf, P>(
+        &self,
+        collection: &SelfRefColMut<'rf, 'a, V, T, P>,
+    ) -> Option<&'a Node<'a, V, T>>
+    where
+        P: PinnedVec<Node<'a, V, T>>,
+    {
+        collection.index_to_maybe_ref(self)
+    }
+
+    /// Converts the node index to a reference to the node in the `collection`.
+    /// The call panics if `self.is_valid_for_collection(collection)` is false; i.e., if this node index is not valid for the given `collection`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `is_valid_for_collection(collection)` returns false.
+    ///
+    /// Note that `is_valid_for_collection` returns true if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub fn as_ref<'rf, P>(&self, collection: &SelfRefColMut<'rf, 'a, V, T, P>) -> &'a Node<'a, V, T>
+    where
+        P: PinnedVec<Node<'a, V, T>>,
+    {
+        collection.index_to_ref(self)
+    }
+
+    /// Converts the node index to a reference to the node in the `collection`.
+    ///
+    /// # Safety
+    ///
+    /// The safe conversion can be performed by `as_ref`, and a safer conversion by `get_ref`.
+    ///
+    /// This method is unsafe as the reference to the node held internally might have been invalidated between time it was created and it is used.
+    ///
+    /// Therefore, the caller takes responsibility that the references are not invalidated.
+    /// In this case, omitting safety and correctness checks, this method provides the fastest access to the node.
+    ///
+    /// Let's call the collection that will be accessed by this index ``collection``.
+    /// The caller can be confident that the node index is still valid for this `collection`
+    /// if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub unsafe fn as_ref_unchecked(&self) -> &'a Node<'a, V, T> {
+        self.node_key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orx_split_vec::{Recursive, SplitVec};
+
+    use crate::{
+        variants::memory_reclaim::MemoryReclaimPolicy, MemoryReclaimOnThreshold, Node,
+        NodeDataLazyClose, NodeIndex, NodeRefSingle, NodeRefsArray, NodeRefsVec, SelfRefCol,
+        SelfRefColMut, Variant,
+    };
+
+    #[derive(Clone, Copy, Debug)]
+    struct Var;
+    impl<'a> Variant<'a, char> for Var {
+        type Storage = NodeDataLazyClose<char>;
+        type Prev = NodeRefSingle<'a, Self, char>;
+        type Next = NodeRefsVec<'a, Self, char>;
+        type Ends = NodeRefsArray<'a, 2, Self, char>;
+        type MemoryReclaim = MemoryReclaimOnThreshold<2>;
+    }
+
+    #[test]
+    fn new_clone() {
+        let node = Node::<Var, _>::new_free_node('x');
+        let reclaim: MemoryReclaimOnThreshold<2> = MemoryReclaimOnThreshold::default();
+
+        let index = NodeIndex::new(reclaim, &node);
+        #[allow(clippy::clone_on_copy)]
+        let clone = index.clone();
+
+        assert!(index.node_key.ref_eq(&node));
+        assert!(clone.node_key.ref_eq(&node));
+
+        assert!(<MemoryReclaimOnThreshold<2> as MemoryReclaimPolicy<
+            '_,
+            Var,
+            _,
+            _,
+            _,
+        >>::is_same_collection_as(
+            &index.collection_key, &reclaim,
+        ));
+
+        assert!(<MemoryReclaimOnThreshold<2> as MemoryReclaimPolicy<
+            '_,
+            Var,
+            _,
+            _,
+            _,
+        >>::is_same_collection_as(
+            &clone.collection_key, &reclaim,
+        ));
+    }
+
+    #[test]
+    fn eq() {
+        let mut col = SelfRefCol::<Var, _>::new();
+
+        let a1 = col.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+        let a2 = col.mutate_take((), |x, _| x.first_node().expect("is-some").index(&x));
+
+        assert!(a1.eq(&a2));
+        assert_eq!(&a1, &a2);
+    }
+
+    #[test]
+    fn is_valid_for_collection() {
+        let mut col = SelfRefCol::<Var, _>::new();
+
+        let a = col.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+        assert!(a.is_valid_for_collection(&col));
+
+        let b = col.mutate_take('b', |x, a| x.push_get_ref(a).index(&x));
+        assert!(a.is_valid_for_collection(&col));
+        assert!(b.is_valid_for_collection(&col));
+    }
+
+    #[test]
+    fn is_invalid_belongs_to_different_collection() {
+        let mut col1 = SelfRefCol::<Var, _>::new();
+        let a = col1.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+
+        let col2 = SelfRefCol::<Var, _>::new();
+
+        assert!(!a.is_valid_for_collection(&col2));
+    }
+
+    #[test]
+    fn is_invalid_because_removed() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [a, b, c, d, e, f, g] = col
+            .mutate_take(['a', 'b', 'c', 'd', 'e', 'f', 'g'], |x, values| {
+                values.map(|val| x.push_get_ref(val).index(&x))
+            });
+
+        let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // does not trigger reclaim yet
+        assert_eq!(removed_b, 'b');
+
+        assert!(a.is_valid_for_collection(&col));
+        assert!(c.is_valid_for_collection(&col));
+        assert!(d.is_valid_for_collection(&col));
+        assert!(e.is_valid_for_collection(&col));
+        assert!(f.is_valid_for_collection(&col));
+        assert!(g.is_valid_for_collection(&col));
+
+        assert!(!b.is_valid_for_collection(&col));
+    }
+
+    #[test]
+    fn is_invalid_because_reorganized() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [a, b, c] = col.mutate_take(['a', 'b', 'c'], |x, values| {
+            values.map(|val| x.push_get_ref(val).index(&x))
+        });
+
+        let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // triggers reclaim
+        assert_eq!(removed_b, 'b');
+
+        assert!(!a.is_valid_for_collection(&col));
+        assert!(!b.is_valid_for_collection(&col));
+        assert!(!c.is_valid_for_collection(&col));
+    }
+
+    #[test]
+    fn get_as_ref_when_valid() {
+        let mut col = SelfRefCol::<Var, _>::new();
+
+        let a = col.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+        let b = col.mutate_take('b', |x, a| x.push_get_ref(a).index(&x));
+
+        col.mutate((a, b), |x, (a, b)| {
+            assert_node_ref_is_valid(&x, a, 'a');
+            assert_node_ref_is_valid(&x, b, 'b');
+        });
+    }
+
+    #[test]
+    fn get_ref_invalid_belongs_to_different_collection() {
+        let mut col1 = SelfRefCol::<Var, _>::new();
+        let a = col1.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+
+        let mut col2 = SelfRefCol::<Var, _>::new();
+        col2.mutate(a, |x, a| assert_node_ref_is_invalid(&x, a));
+    }
+
+    #[test]
+    #[should_panic]
+    fn as_ref_invalid_belongs_to_different_collection() {
+        let mut col1 = SelfRefCol::<Var, _>::new();
+        let a = col1.mutate_take('a', |x, a| x.push_get_ref(a).index(&x));
+
+        let mut col2 = SelfRefCol::<Var, _>::new();
+
+        col2.mutate(a, |x, a| {
+            a.as_ref(&x);
+        });
+    }
+
+    #[test]
+    fn get_ref_invalid_because_removed() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [a, b, c, d, e, f, g] = col
+            .mutate_take(['a', 'b', 'c', 'd', 'e', 'f', 'g'], |x, values| {
+                values.map(|val| x.push_get_ref(val).index(&x))
+            });
+
+        let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // does not trigger reclaim yet
+        assert_eq!(removed_b, 'b');
+
+        col.mutate((a, b, c, d, e, f, g), |x, (a, b, c, d, e, f, g)| {
+            assert_node_ref_is_valid(&x, a, 'a');
+            assert_node_ref_is_invalid(&x, b);
+            assert_node_ref_is_valid(&x, c, 'c');
+            assert_node_ref_is_valid(&x, d, 'd');
+            assert_node_ref_is_valid(&x, e, 'e');
+            assert_node_ref_is_valid(&x, f, 'f');
+            assert_node_ref_is_valid(&x, g, 'g');
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn as_ref_invalid_because_removed() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [_, b, _, _, _, _, _] = col
+            .mutate_take(['a', 'b', 'c', 'd', 'e', 'f', 'g'], |x, values| {
+                values.map(|val| x.push_get_ref(val).index(&x))
+            });
+
+        let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // does not trigger reclaim yet
+        assert_eq!(removed_b, 'b');
+
+        col.mutate(b, |x, b| {
+            b.as_ref(&x);
+        });
+    }
+
+    #[test]
+    fn get_ref_invalid_because_reorganized() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [a, b, c] = col.mutate_take(['a', 'b', 'c'], |x, values| {
+            values.map(|val| x.push_get_ref(val).index(&x))
+        });
+
+        let _ = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // triggers reclaim
+
+        col.mutate((a, b, c), |x, (a, b, c)| {
+            assert_node_ref_is_invalid(&x, a);
+            assert_node_ref_is_invalid(&x, b);
+            assert_node_ref_is_invalid(&x, c);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn as_ref_invalid_because_reorganized() {
+        let mut col = SelfRefCol::<Var, _>::new();
+        let [a, b, _] = col.mutate_take(['a', 'b', 'c'], |x, values| {
+            values.map(|val| x.push_get_ref(val).index(&x))
+        });
+
+        let _ = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // triggers reclaim
+
+        col.mutate(a, |x, a| {
+            a.as_ref(&x);
+        });
+    }
+
+    // helpers
+    fn assert_node_ref_is_valid<'a>(
+        x: &SelfRefColMut<'_, 'a, Var, char, SplitVec<Node<'a, Var, char>, Recursive>>,
+        node_index: NodeIndex<'a, Var, char>,
+        expected_value: char,
+    ) {
+        assert_eq!(
+            node_index.get_ref(x).and_then(|a| a.data()),
+            Some(&expected_value)
+        );
+        assert_eq!(node_index.as_ref(x).data(), Some(&expected_value));
+        assert_eq!(
+            unsafe { node_index.as_ref_unchecked().data() },
+            Some(&expected_value)
+        );
+    }
+
+    fn assert_node_ref_is_invalid<'a>(
+        x: &SelfRefColMut<'_, 'a, Var, char, SplitVec<Node<'a, Var, char>, Recursive>>,
+        node_index: NodeIndex<'a, Var, char>,
+    ) {
+        assert!(node_index.get_ref(x).is_none());
+    }
+}

--- a/src/nodes/lazy_data.rs
+++ b/src/nodes/lazy_data.rs
@@ -18,12 +18,6 @@ where
     pub fn is_closed(&self) -> bool {
         self.data.is_closed()
     }
-
-    /// Returns whether the node is active or not.
-    #[inline(always)]
-    pub fn is_active(&self) -> bool {
-        self.data.is_active()
-    }
 }
 
 #[cfg(test)]
@@ -31,6 +25,7 @@ mod tests {
     use super::*;
     use crate::{MemoryReclaimOnThreshold, NodeRefNone, NodeRefSingle, NodeRefs, NodeRefsVec};
 
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, char> for Var {
         type Storage = NodeDataLazyClose<char>;

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -1,2 +1,4 @@
+pub mod can_leak;
+pub mod index;
 mod lazy_data;
 pub mod node;

--- a/src/references/array.rs
+++ b/src/references/array.rs
@@ -114,6 +114,7 @@ mod tests {
     use super::*;
     use crate::{MemoryReclaimNever, NodeData, NodeDataEagerClose, NodeRefNone};
 
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, char> for Var {
         type Storage = NodeDataEagerClose<char>;

--- a/src/references/none.rs
+++ b/src/references/none.rs
@@ -49,6 +49,7 @@ mod tests {
     use super::*;
     use crate::{MemoryReclaimNever, NodeData, NodeDataLazyClose};
 
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, char> for Var {
         type Storage = NodeDataLazyClose<char>;

--- a/src/references/single.rs
+++ b/src/references/single.rs
@@ -117,6 +117,7 @@ mod tests {
     use super::*;
     use crate::{MemoryReclaimNever, NodeData, NodeDataEagerClose, NodeRefNone};
 
+    #[derive(Debug, Clone, Copy)]
     struct TestVar;
     impl<'a> Variant<'a, char> for TestVar {
         type Storage = NodeDataEagerClose<char>;

--- a/src/references/vec.rs
+++ b/src/references/vec.rs
@@ -105,6 +105,7 @@ mod tests {
     use super::*;
     use crate::{MemoryReclaimNever, NodeData, NodeDataEagerClose, NodeRefNone};
 
+    #[derive(Debug, Clone, Copy)]
     struct Var;
     impl<'a> Variant<'a, char> for Var {
         type Storage = NodeDataEagerClose<char>;

--- a/src/variants/variant.rs
+++ b/src/variants/variant.rs
@@ -1,9 +1,8 @@
+use super::memory_reclaim::MemoryReclaimPolicy;
 use crate::{data::node_data::NodeData, references::node_refs::NodeRefs};
 
-use super::memory_reclaim::MemoryReclaimPolicy;
-
 /// Variant defining `SelfRefCol` specifications.
-pub trait Variant<'a, T>
+pub trait Variant<'a, T>: Clone + Copy
 where
     Self: Sized,
 {


### PR DESCRIPTION
* `NodeIndex`is defined.
  * A node index can be created by a `Node`s `index(&self)` method. Note that since `Node` struct can never leak out of the `SelfRefCol`, node indices can only be created inside a mutation method.
  * Node index is analogous to `usize` for an `std::vec::Vec` due to the following:
    * it represents a direct access to the element allowing a constant time random access,
    * it can be stored as a value, completely independent of the collection.
  * `NodeIndex` provides additional safety and correctness features: * it is not possible to use a `NodeIndex` generated from one collection to access an element of another. * it is not possible to use a `NodeIndex` if it no longer points to the element which it was created for, probably due to removal or reorganization of the elements.
* `CanLeak` trait is defined.
  * It is critical for safety features of `SelfRefCol` to limit the types which mutation methods can return. In the prior version, this was limited to `Option<T>` where `T` is the value type of the element. This would prevent leaking of any references.
  * Now, mutation methods can return any type implementing `CanLeak`. Currently, the following types implement `CanLeak`:
    * `T`, `Option<T>`, `Vec<T>`, `[T; N]`,
    * `NodeIndex`, `Option<NodeIndex>`, `Vec<NodeIndex>`, `[NodeIndex; N]`,
  * Note that it is safe to return `NodeIndex` due to its extended safety features as explained above.
* `MemoryState` is introduced.
  * Whenever closed nodes of a `SelfRefCol` are reclaimed, the state changes.
  * This state is used to validate leaked node indices.
  * In other words, it is not possible to use a `NodeIndex` which is invalidated due to a memory reclaim operation, which is proven by mismatch of the memory states.