### PR TITLE
non mutating node traversal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-selfref-col"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`SelfRefCol` is a core data structure to conveniently build safe and efficient self referential collections, such as linked lists and trees."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ mod nodes;
 mod references;
 mod selfref_col;
 mod selfref_col_mut;
+mod selfref_col_visit;
 mod variants;
 
 pub use data::{
@@ -255,5 +256,6 @@ pub use references::{
 };
 pub use selfref_col::SelfRefCol;
 pub use selfref_col_mut::SelfRefColMut;
+pub use selfref_col_visit::SelfRefColVisit;
 pub use variants::memory_reclaim::{MemoryReclaimNever, MemoryReclaimOnThreshold};
 pub use variants::variant::Variant;

--- a/src/nodes/can_leak.rs
+++ b/src/nodes/can_leak.rs
@@ -1,4 +1,4 @@
-use crate::{nodes::index::NodeIndex, Node, Variant};
+use crate::{nodes::index::NodeIndex, Node, NodeIndexError, Variant};
 use orx_split_vec::prelude::PinnedVec;
 
 /// Marker trait for types which are safe to leak out of the `SelfRefCol`.
@@ -18,89 +18,53 @@ where
 {
 }
 
-// T
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for T
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
+macro_rules! impl_can_leak {
+    ($x:ty) => {
+        impl<'a, V, T, P> CanLeak<'a, V, T, P> for $x
+        where
+            V: Variant<'a, T>,
+            P: PinnedVec<Node<'a, V, T>>,
+        {
+        }
+
+        impl<'a, V, T, P> CanLeak<'a, V, T, P> for Result<$x, NodeIndexError>
+        where
+            V: Variant<'a, T>,
+            P: PinnedVec<Node<'a, V, T>>,
+        {
+        }
+    };
 }
 
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Option<T>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
+macro_rules! impl_can_leak_n {
+    ($x:ty) => {
+        impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for $x
+        where
+            V: Variant<'a, T>,
+            P: PinnedVec<Node<'a, V, T>>,
+        {
+        }
+
+        impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for Result<$x, NodeIndexError>
+        where
+            V: Variant<'a, T>,
+            P: PinnedVec<Node<'a, V, T>>,
+        {
+        }
+    };
 }
 
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Vec<T>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
+impl_can_leak!(T);
+impl_can_leak!(Option<T>);
+impl_can_leak!(Vec<T>);
+impl_can_leak_n!([T; N]);
 
-impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for [T; N]
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
+impl_can_leak!(&T);
+impl_can_leak!(Option<&T>);
+impl_can_leak!(Vec<&T>);
+impl_can_leak_n!([&T; N]);
 
-// &T
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for &T
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Option<&T>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Vec<&T>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for [&T; N]
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-// NodeIndex
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for NodeIndex<'a, V, T>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Option<NodeIndex<'a, V, T>>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, V, T, P> CanLeak<'a, V, T, P> for Vec<NodeIndex<'a, V, T>>
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
-
-impl<'a, const N: usize, V, T, P> CanLeak<'a, V, T, P> for [NodeIndex<'a, V, T>; N]
-where
-    V: Variant<'a, T>,
-    P: PinnedVec<Node<'a, V, T>>,
-{
-}
+impl_can_leak!(NodeIndex<'a, V, T>);
+impl_can_leak!(Option<NodeIndex<'a, V, T>>);
+impl_can_leak!(Vec<NodeIndex<'a, V, T>>);
+impl_can_leak_n!([NodeIndex<'a, V, T>; N]);

--- a/src/nodes/has_collection_key.rs
+++ b/src/nodes/has_collection_key.rs
@@ -1,0 +1,29 @@
+use crate::{Node, SelfRefColMut, SelfRefColVisit, Variant};
+use orx_split_vec::prelude::PinnedVec;
+
+pub trait HasCollectionKey<'a, V, T>
+where
+    V: Variant<'a, T>,
+{
+    fn collection_key(&self) -> V::MemoryReclaim;
+}
+
+impl<'rf, 'a, V, T, P> HasCollectionKey<'a, V, T> for SelfRefColVisit<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+    fn collection_key(&self) -> V::MemoryReclaim {
+        self.col.memory_reclaim_policy
+    }
+}
+
+impl<'rf, 'a, V, T, P> HasCollectionKey<'a, V, T> for SelfRefColMut<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+    fn collection_key(&self) -> V::MemoryReclaim {
+        self.col.memory_reclaim_policy
+    }
+}

--- a/src/nodes/index_error.rs
+++ b/src/nodes/index_error.rs
@@ -29,7 +29,7 @@ pub enum NodeIndexError {
     ///         values.map(|val| x.push_get_ref(val).index(&x))
     ///     });
     ///
-    /// let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x)); // does not trigger reclaim yet
+    /// let removed_b = col.mutate_take(b, |x, b| x.as_node_ref(b).close_node_take_data(&x)); // does not trigger reclaim yet
     /// assert_eq!(removed_b, 'b');
     ///
     /// assert_eq!(a.invalidity_reason_for_collection(&col), None);
@@ -87,7 +87,7 @@ pub enum NodeIndexError {
     /// });
     ///
     /// // triggers memory reclaim, invalidating all prior node indices
-    /// let removed_b = col.mutate_take(b, |x, b| b.as_ref(&x).close_node_take_data(&x));
+    /// let removed_b = col.mutate_take(b, |x, b| x.as_node_ref(b).close_node_take_data(&x));
     /// assert_eq!(removed_b, 'b');
     ///
     /// assert_eq!(a.invalidity_reason_for_collection(&col), Some(NodeIndexError::ReorganizedCollection));

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -1,4 +1,5 @@
 pub mod can_leak;
+pub mod has_collection_key;
 pub mod index;
 pub mod index_error;
 mod lazy_data;

--- a/src/selfref_col_visit.rs
+++ b/src/selfref_col_visit.rs
@@ -1,0 +1,133 @@
+use crate::{
+    nodes::index::NodeIndex, selfref_col_mut::into_ref, Node, NodeIndexError, SelfRefCol,
+    SelfRefColMut, Variant,
+};
+use orx_split_vec::prelude::PinnedVec;
+use std::ops::Deref;
+
+/// Struct allowing to safely, conveniently and efficiently visit nodes of a self referential collection and take `CanLeak` values out.
+///
+/// # Safety
+///
+/// This struct holds an immutable reference to the underlying self referential collection.
+///
+/// This struct cannot be created externally.
+/// It is only constructed by `SelfRefCol`s methods such as `visit` and `visit_take` methods.
+/// You may find corresponding safety guarantees in the documentation of these methods, which in brief, relies on careful encapsulation
+/// preventing any reference to leak into the collection or any node reference to leak out.
+pub struct SelfRefColVisit<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+    'a: 'rf,
+{
+    pub(crate) col: &'rf SelfRefCol<'a, V, T, P>,
+}
+
+impl<'rf, 'a, V, T, P> SelfRefColVisit<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+    pub(crate) fn new(vec: &'rf SelfRefCol<'a, V, T, P>) -> Self {
+        Self { col: vec }
+    }
+
+    // index
+    /// ***O(1)*** Converts the `node_index` to `Some` of the valid reference to the node in this collection.
+    ///
+    /// If the node index is invalid, the method returns `None`.
+    ///
+    /// Note that the validity of the node index can also be queried by `node_index::is_valid_for_collection` method.
+    ///
+    /// `get_node_ref(collection)` returns `Some` if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub fn get_node_ref(&self, node_index: NodeIndex<'a, V, T>) -> Option<&'a Node<'a, V, T>> {
+        match node_index.is_valid_for_collection(self.col) {
+            true => Some(node_index.node_key),
+            false => None,
+        }
+    }
+
+    /// ***O(1)*** Converts the `node_index` to a `Ok` of the valid reference to the node in this collection.
+    ///
+    /// If the node index is invalid, the method returns `Err` of the corresponding `NodeIndexError` depending on the reason of invalidity.
+    ///
+    /// Note that the corresponding error can also be queried by `node_index::invalidity_reason_for_collection` method.
+    ///
+    /// `get_node_ref_or_error(collection)` returns `Ok` if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub fn get_node_ref_or_error(
+        &self,
+        node_index: NodeIndex<'a, V, T>,
+    ) -> Result<&'a Node<'a, V, T>, NodeIndexError>
+    where
+        P: PinnedVec<Node<'a, V, T>>,
+    {
+        match node_index.invalidity_reason_for_collection(self.col) {
+            None => Ok(node_index.node_key),
+            Some(error) => Err(error),
+        }
+    }
+
+    /// ***O(1)*** Converts the `node_index` to a reference to the node in this collection.
+    /// The call panics if `node_index.is_valid_for_collection(collection)` is false; i.e., if this node index is not valid for this collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node index is invalid; i.e., if `node_index.is_valid_for_collection` returns false.
+    ///
+    /// Note that `is_valid_for_collection` returns true if all of of the following safety and correctness conditions hold:
+    /// * this index is created from the given `collection`,
+    /// * the node this index is created for still belongs to the `collection`; i.e., is not removed,
+    /// * the node positions in the `collection` are not reorganized to reclaim memory.
+    #[inline(always)]
+    pub fn as_node_ref(&self, node_index: NodeIndex<'a, V, T>) -> &'a Node<'a, V, T> {
+        assert!(node_index.is_valid_for_collection(self.col));
+        node_index.node_key
+    }
+
+    // nodes
+    /// Returns a reference to the first node of the collection.
+    pub fn first_node<'b>(&self) -> Option<&'b Node<'a, V, T>> {
+        self.col.pinned_vec.first().map(|x| unsafe { into_ref(x) })
+    }
+
+    /// Returns a reference to the last node of the collection.
+    pub fn last_node<'b>(&self) -> Option<&'b Node<'a, V, T>> {
+        self.col.pinned_vec.last().map(|x| unsafe { into_ref(x) })
+    }
+
+    /// Returns a reference to the `at`-th node of the collection.
+    pub fn get_node<'b>(&self, at: usize) -> Option<&'b Node<'a, V, T>> {
+        self.col.pinned_vec.get(at).map(|x| unsafe { into_ref(x) })
+    }
+}
+
+impl<'rf, 'a, V, T, P> Deref for SelfRefColVisit<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+    type Target = SelfRefCol<'a, V, T, P>;
+
+    fn deref(&self) -> &Self::Target {
+        self.col
+    }
+}
+
+impl<'rf, 'a, V, T, P> From<&SelfRefColMut<'rf, 'a, V, T, P>> for SelfRefColVisit<'rf, 'a, V, T, P>
+where
+    V: Variant<'a, T>,
+    P: PinnedVec<Node<'a, V, T>>,
+{
+    fn from(value: &SelfRefColMut<'rf, 'a, V, T, P>) -> Self {
+        Self::new(unsafe { into_ref(value.col) })
+    }
+}

--- a/src/variants/memory_reclaim.rs
+++ b/src/variants/memory_reclaim.rs
@@ -4,6 +4,14 @@ use crate::{
 };
 use orx_split_vec::prelude::PinnedVec;
 
+/// Policy which determines how the memory of closed nodes will be reclaimed and made useful.
+///
+/// Two main implementors are:
+/// * [`MemoryReclaimOnThreshold<N>`] reclaims unused holes whenever the utilization of the memory falls below a constant threshold determined by `N`.
+/// This could be considered as the flexible and general approach.
+/// * [`MemoryReclaimNever`] which never reclaims the holes due to popped or removed; i.e., closed, nodes.
+/// This approach has the advantage that a `NodeIndex` is never invalidated due to memory reorganization.
+/// Therefore, it fits very well to situations where removals from the list is not substantial.
 pub trait MemoryReclaimPolicy<'a, V, T, Prev, Next>: Default + Clone + Copy
 where
     V: Variant<'a, T, Prev = Prev, Next = Next>,


### PR DESCRIPTION
* `CanLeak` implementations are handled by a simple macro.
* `CanLeak` implementations are extended to `Result<X, NodeIndexError>` of `X` that implements `CanLeak`.
* `SelfRefColVisit` is introduced for non-mutating traversal through nodes of the collection, following references.
* `SelfRefCol::visit_take` method is defined.
* `node_index.get_ref(x)` is transposed as `x.get_node_ref(node_index)`. *