### PR TITLE
`MemoryReclaimPolicy` types simplified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-selfref-col"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`SelfRefCol` is a core data structure to conveniently build safe and efficient self referential collections, such as linked lists and trees."
@@ -10,7 +10,7 @@ keywords = ["self-referential", "list", "tree", "recursive", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-split-vec = "2.1"
+orx-split-vec = "2.3"
 
 [dev-dependencies]
 test-case = "3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,5 +257,7 @@ pub use references::{
 pub use selfref_col::SelfRefCol;
 pub use selfref_col_mut::SelfRefColMut;
 pub use selfref_col_visit::SelfRefColVisit;
-pub use variants::memory_reclaim::{MemoryReclaimNever, MemoryReclaimOnThreshold};
+pub use variants::memory_reclaim::{
+    MemoryReclaimNever, MemoryReclaimOnThreshold, MemoryReclaimPolicy, Reclaim,
+};
 pub use variants::variant::Variant;

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -1,4 +1,5 @@
 use crate::data::node_data::NodeData;
+use crate::variants::memory_reclaim::Reclaim;
 use crate::variants::variant::Variant;
 use crate::{NodeDataLazyClose, NodeIndex, NodeRefsArray, NodeRefsVec, SelfRefColMut};
 use orx_split_vec::prelude::PinnedVec;
@@ -169,6 +170,7 @@ where
     where
         V: Variant<'a, T, Storage = NodeDataLazyClose<T>>,
         P: PinnedVec<Node<'a, V, T>> + 'a,
+        SelfRefColMut<'rf, 'a, V, T, P>: Reclaim<V::Prev, V::Next>,
     {
         vec_mut.close_node_take_data(self)
     }
@@ -187,6 +189,7 @@ where
     where
         V: Variant<'a, T, Storage = NodeDataLazyClose<T>>,
         P: PinnedVec<Node<'a, V, T>> + 'a,
+        SelfRefColMut<'rf, 'a, V, T, P>: Reclaim<V::Prev, V::Next>,
     {
         vec_mut.close_node_take_data_no_reclaim(self)
     }

--- a/src/selfref_col_mut.rs
+++ b/src/selfref_col_mut.rs
@@ -1,6 +1,8 @@
 use crate::{
-    nodes::index::NodeIndex, variants::memory_reclaim::MemoryReclaimPolicy, Node, NodeData,
-    NodeDataLazyClose, NodeIndexError, NodeRefs, NodeRefsArray, NodeRefsVec, SelfRefCol, Variant,
+    nodes::index::NodeIndex,
+    variants::memory_reclaim::{MemoryReclaimPolicy, Reclaim},
+    Node, NodeData, NodeDataLazyClose, NodeIndexError, NodeRefs, NodeRefsArray, NodeRefsVec,
+    SelfRefCol, Variant,
 };
 use orx_split_vec::prelude::PinnedVec;
 use std::ops::Deref;
@@ -314,6 +316,7 @@ impl<'rf, 'a, V, T, P> SelfRefColMut<'rf, 'a, V, T, P>
 where
     V: Variant<'a, T, Storage = NodeDataLazyClose<T>>,
     P: PinnedVec<Node<'a, V, T>> + 'a,
+    SelfRefColMut<'rf, 'a, V, T, P>: Reclaim<V::Prev, V::Next>,
 {
     pub(crate) fn close_node_take_data_no_reclaim(&self, node: &'a Node<'a, V, T>) -> T {
         debug_assert!(node.data.is_active());

--- a/src/variants/variant.rs
+++ b/src/variants/variant.rs
@@ -37,7 +37,7 @@ where
     type Ends: NodeRefs<'a, Self, T>;
 
     /// The way how memory of closed nodes will be reclaimed:
-    /// * `MemoryReclaimNever` will never claim closed nodes.
+    /// * `MemoryReclaimNever` will never automatically claim closed nodes.
     /// * `MemoryReclaimOnThreshold<D>` will claim memory of closed nodes whenever the ratio of closed nodes exceeds one over `2^D`.
-    type MemoryReclaim: MemoryReclaimPolicy<'a, Self, T, Self::Prev, Self::Next>;
+    type MemoryReclaim: MemoryReclaimPolicy;
 }


### PR DESCRIPTION
* `MemoryReclaimPolicy` generic arguments are simplified.
* `MemoryReclaimNever` is now safe against manual `reclaim_closed_nodes` calls.
* `Reclaim` trait is defined to define how the reclaim operation will be handled depending on the references.
* `impl_reclaim_unidirectional` and `impl_reclaim_bidirectional` macros are utilized to implement `Reclaim` for different (prev, next) type combinations.

Fixes #2 