### PR TITLE
hotfix in `append_mutate` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-selfref-col"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "`SelfRefCol` is a core data structure to conveniently build safe and efficient self referential collections, such as linked lists and trees."
@@ -10,9 +10,8 @@ keywords = ["self-referential", "list", "tree", "recursive", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.7"
-orx-split-vec = "2.8"
-
+orx-pinned-vec = "2.11"
+orx-split-vec = "2.13"
 
 [dev-dependencies]
 test-case = "3.3"

--- a/src/nodes/index_error.rs
+++ b/src/nodes/index_error.rs
@@ -93,6 +93,7 @@ pub enum NodeIndexError {
     /// assert_eq!(a.invalidity_reason_for_collection(&col), Some(NodeIndexError::ReorganizedCollection));
     /// assert_eq!(b.invalidity_reason_for_collection(&col), Some(NodeIndexError::ReorganizedCollection));
     /// assert_eq!(c.invalidity_reason_for_collection(&col), Some(NodeIndexError::ReorganizedCollection));
+    /// ```
     ReorganizedCollection,
 }
 

--- a/src/nodes/node.rs
+++ b/src/nodes/node.rs
@@ -260,6 +260,12 @@ where
         let left = self as *const Self;
         left == other
     }
+
+    #[cfg(test)]
+    pub(crate) fn refetch(&self) -> &Self {
+        let raw = std::hint::black_box(self as *const Self);
+        unsafe { &*raw }
+    }
 }
 
 impl<'a, V, T> Clone for Node<'a, V, T>
@@ -392,6 +398,8 @@ mod tests {
 
             let val_a = a.close_node_take_data(&x);
             assert_eq!('a', val_a);
+
+            let a = a.refetch();
             assert!(a.is_closed());
         }
     }
@@ -478,6 +486,7 @@ mod tests {
             assert!(a.prev().get().unwrap().ref_eq(b));
 
             a.clear_prev(&x);
+            let (a, b) = (a.refetch(), b.refetch());
             assert!(a.prev().get().is_none());
 
             a.set_prev_refs(&x, NodeRefSingle::empty());
@@ -490,6 +499,7 @@ mod tests {
             assert!(b.next().get().unwrap().ref_eq(a));
 
             b.clear_next(&x);
+            let (a, b) = (a.refetch(), b.refetch());
             assert!(b.next().get().is_none());
 
             a.set_next(&x, b);
@@ -608,6 +618,7 @@ mod tests {
             assert!(b.prev().get()[0].is_none());
 
             b.set_prev(&x, [Some(c)]);
+            let (b, c) = (b.refetch(), c.refetch());
             assert!(b.prev().get()[0].unwrap().ref_eq(c));
 
             b.clear_prev(&x);


### PR DESCRIPTION
Removed dependency to unsafe in append-mutate is removed.