### PR TITLE
Towards tree support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-selfref-col"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "SelfRefCol is a core data structure to conveniently build safe and efficient self referential collections, such as linked lists and trees."

--- a/src/core_col.rs
+++ b/src/core_col.rs
@@ -199,7 +199,13 @@ where
     /// Does nothing and returns None if the node was already closed.
     pub fn close_if_active(&mut self, node_ptr: &NodePtr<V>) -> Option<V::Item> {
         let node = unsafe { &mut *node_ptr.ptr_mut() };
-        node.is_active().then(|| node.close())
+        match node.is_active() {
+            true => {
+                self.len -= 1;
+                Some(node.close())
+            }
+            false => None,
+        }
     }
 
     /// Returns a mutable reference to the ends of the collection.

--- a/src/core_col.rs
+++ b/src/core_col.rs
@@ -89,14 +89,14 @@ where
     /// Returns a reference to the node with the given `node_ptr`.
     #[inline(always)]
     pub fn node(&self, node_ptr: &NodePtr<V>) -> &Node<V> {
-        unsafe { &*node_ptr.ptr() }
+        unsafe { &*node_ptr.ptr_mut() }
     }
 
     /// Returns the position of the node with the given `node_ptr`,
     /// None if the pointer is not valid.
     #[inline(always)]
     pub fn position_of(&self, node_ptr: &NodePtr<V>) -> Option<usize> {
-        self.nodes.index_of_ptr(node_ptr.ptr())
+        self.nodes.index_of_ptr(node_ptr.ptr_mut())
     }
 
     /// Returns the position of the node with the given `node_ptr`.
@@ -107,7 +107,7 @@ where
     #[inline(always)]
     pub fn position_of_unchecked(&self, node_ptr: &NodePtr<V>) -> usize {
         self.nodes
-            .index_of_ptr(node_ptr.ptr())
+            .index_of_ptr(node_ptr.ptr_mut())
             .expect("Pointer does not belong to the collection")
     }
 
@@ -123,7 +123,9 @@ where
     /// `node_ptr` belongs to (created from) this collection.
     #[inline(always)]
     pub unsafe fn data_unchecked(&self, node_ptr: &NodePtr<V>) -> &V::Item {
-        unsafe { &*node_ptr.ptr() }.data().expect("node is closed")
+        unsafe { &*node_ptr.ptr_mut() }
+            .data()
+            .expect("node is closed")
     }
 
     /// Returns a reference to the ends of the collection.
@@ -177,7 +179,7 @@ where
     /// `node_ptr` belongs to (created from) this collection.
     #[inline(always)]
     pub unsafe fn data_mut_unchecked(&mut self, node_ptr: &NodePtr<V>) -> &mut V::Item {
-        unsafe { &mut *node_ptr.ptr() }
+        unsafe { &mut *node_ptr.ptr_mut() }
             .data_mut()
             .expect("node is closed")
     }
@@ -190,7 +192,7 @@ where
     #[inline(always)]
     pub fn close(&mut self, node_ptr: &NodePtr<V>) -> V::Item {
         self.len -= 1;
-        unsafe { &mut *node_ptr.ptr() }.close()
+        unsafe { &mut *node_ptr.ptr_mut() }.close()
     }
 
     /// Returns a mutable reference to the ends of the collection.
@@ -201,7 +203,7 @@ where
     /// Returns a mutable reference to the node with the given `node_ptr`.
     #[inline(always)]
     pub fn node_mut(&mut self, node_ptr: &NodePtr<V>) -> &mut Node<V> {
-        unsafe { &mut *node_ptr.ptr() }
+        unsafe { &mut *node_ptr.ptr_mut() }
     }
 
     /// Swaps the closed node at the `closed_position` with the active node
@@ -222,7 +224,7 @@ where
     ///
     /// Panics if the node was already closed.
     pub fn swap_data(&mut self, node_ptr: &NodePtr<V>, new_value: V::Item) -> V::Item {
-        let node = unsafe { &mut *node_ptr.ptr() };
+        let node = unsafe { &mut *node_ptr.ptr_mut() };
         node.swap_data(new_value)
     }
 }

--- a/src/core_col.rs
+++ b/src/core_col.rs
@@ -195,6 +195,13 @@ where
         unsafe { &mut *node_ptr.ptr_mut() }.close()
     }
 
+    /// Closes the node at the given `node_ptr` and returns its data the node was active.
+    /// Does nothing and returns None if the node was already closed.
+    pub fn close_if_active(&mut self, node_ptr: &NodePtr<V>) -> Option<V::Item> {
+        let node = unsafe { &mut *node_ptr.ptr_mut() };
+        node.is_active().then(|| node.close())
+    }
+
     /// Returns a mutable reference to the ends of the collection.
     pub fn ends_mut(&mut self) -> &mut V::Ends {
         &mut self.ends

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,12 @@
 #![no_std]
 extern crate alloc;
 
+pub mod references;
+
 mod common_traits;
 mod core_col;
 mod memory;
 mod node;
-mod references;
 mod selfref_col;
 mod variant;
 
@@ -28,6 +29,6 @@ pub use memory::{
 };
 pub use node::Node;
 pub use references::{NodeIdx, NodeIdxError, NodePtr};
-pub use references::{Refs, RefsArray, RefsNone, RefsSingle, RefsVec};
+pub use references::{Refs, RefsArray, RefsArrayLeftMost, RefsNone, RefsSingle, RefsVec};
 pub use selfref_col::SelfRefCol;
 pub use variant::Variant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![no_std]
 extern crate alloc;
 
+/// Node references.
 pub mod references;
 
 mod common_traits;

--- a/src/references/array.rs
+++ b/src/references/array.rs
@@ -37,24 +37,24 @@ where
 }
 
 impl<const N: usize, V: Variant> RefsArray<N, V> {
-    /// Returns the node pointer a the `ref_idx` position of the references array.
-    pub fn get(&self, ref_idx: usize) -> Option<NodePtr<V>> {
-        self.0[ref_idx].clone()
+    /// Returns the node pointer at the `ref_idx` position of the references array.
+    pub fn get(&self, ref_idx: usize) -> Option<&NodePtr<V>> {
+        self.0[ref_idx].as_ref()
     }
 
     // mut
 
-    /// Sets the the node pointer a the `ref_idx` position of the references array to the given `node_idx`.
+    /// Sets the the node pointer at the `ref_idx` position of the references array to the given `node_idx`.
     pub fn set(&mut self, ref_idx: usize, node_idx: Option<NodePtr<V>>) {
         self.0[ref_idx] = node_idx;
     }
 
-    /// Sets the the node pointer a the `ref_idx` position of the references array to the given `node_idx`.
-    pub fn set_some(&mut self, ref_idx: usize, node_idx: &NodePtr<V>) {
-        self.0[ref_idx] = Some(node_idx.clone())
+    /// Sets the the node pointer at the `ref_idx` position of the references array to the given `node_idx`.
+    pub fn set_some(&mut self, ref_idx: usize, node_idx: NodePtr<V>) {
+        self.0[ref_idx] = Some(node_idx)
     }
 
-    /// Un-sets the the node pointer a the `ref_idx` position of the references array.
+    /// Un-sets the the node pointer at the `ref_idx` position of the references array.
     pub fn set_none(&mut self, ref_idx: usize) {
         self.0[ref_idx] = None
     }

--- a/src/references/array.rs
+++ b/src/references/array.rs
@@ -23,16 +23,39 @@ impl<const N: usize, V> Refs for RefsArray<N, V>
 where
     V: Variant,
 {
+    #[inline(always)]
     fn empty() -> Self {
         Self([const { None }; N])
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.0.iter().all(|x| x.is_none())
     }
 
+    #[inline(always)]
     fn clear(&mut self) {
         self.0.iter_mut().for_each(|x| _ = x.take());
+    }
+
+    #[inline(always)]
+    fn remove_at(&mut self, ref_idx: usize) {
+        self.0[ref_idx] = None;
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, ptr: usize) -> Option<usize> {
+        let x = self.0.iter().enumerate().find(|x| match x.1 {
+            Some(x) => x.ptr() as usize == ptr,
+            None => false,
+        });
+        match x {
+            Some((ref_idx, _)) => {
+                self.0[ref_idx] = None;
+                Some(ref_idx)
+            }
+            None => None,
+        }
     }
 }
 

--- a/src/references/array_left_most.rs
+++ b/src/references/array_left_most.rs
@@ -1,0 +1,110 @@
+use super::{
+    iter::{ArrayLeftMostPtrIter, ArrayLeftMostPtrIterMut},
+    refs::Refs,
+    NodePtr,
+};
+use crate::variant::Variant;
+use core::fmt::Debug;
+
+/// A constant number of left-aligned references.
+///
+/// It differs from [`RefsArray`] due to its additional requirement that:
+/// * all Some references are to the left of all None references.
+///
+/// [`RefsArray`]: crate::RefsArray
+pub struct RefsArrayLeftMost<const N: usize, V>
+where
+    V: Variant,
+{
+    array: [Option<NodePtr<V>>; N],
+    len: usize,
+}
+
+impl<const N: usize, V: Variant> Clone for RefsArrayLeftMost<N, V> {
+    fn clone(&self) -> Self {
+        Self {
+            array: self.array.clone(),
+            len: self.len,
+        }
+    }
+}
+
+impl<const N: usize, V: Variant> Debug for RefsArrayLeftMost<N, V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("RefsArrayLeftMost")
+            .field(&self.array)
+            .finish()
+    }
+}
+
+impl<const N: usize, V> Refs for RefsArrayLeftMost<N, V>
+where
+    V: Variant,
+{
+    fn empty() -> Self {
+        Self {
+            array: [const { None }; N],
+            len: 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn clear(&mut self) {
+        self.array
+            .iter_mut()
+            .take(self.len)
+            .for_each(|x| _ = x.take());
+        self.len = 0;
+    }
+}
+
+impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
+    /// Returns the number of references.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns a reference to the node pointer at the `ref_idx` position of the references array.
+    pub fn get(&self, ref_idx: usize) -> Option<&NodePtr<V>> {
+        self.array[ref_idx].as_ref()
+    }
+
+    /// Returns a mutable reference to the node pointer at the `ref_idx` position of the references array.
+    pub fn get_mut(&mut self, ref_idx: usize) -> Option<&mut NodePtr<V>> {
+        self.array[ref_idx].as_mut()
+    }
+
+    /// Creates an iterator over node pointers of the references collection.
+    pub fn iter(&self) -> ArrayLeftMostPtrIter<V> {
+        ArrayLeftMostPtrIter::new(self.array.iter(), self.len)
+    }
+
+    /// Creates a mutable iterator over node pointers of the references collection.
+    pub fn iter_mut(&mut self) -> ArrayLeftMostPtrIterMut<V> {
+        ArrayLeftMostPtrIterMut::new(self.array.iter_mut(), self.len)
+    }
+
+    /// Returns whether or not the collection has room for another reference.
+    pub fn has_room(&self) -> bool {
+        self.len < N
+    }
+
+    /// Pushes the node references to the end of the references collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the array already has `N` references; i.e., when `self.has_room()` is false.
+    pub fn push(&mut self, node_ptr: NodePtr<V>) {
+        assert!(
+            self.has_room(),
+            "Pushing the {}-th reference to array-backed references with maximum of {} elements.",
+            N + 1,
+            N
+        );
+        self.array[self.len] = Some(node_ptr);
+        self.len += 1;
+    }
+}

--- a/src/references/array_left_most.rs
+++ b/src/references/array_left_most.rs
@@ -132,6 +132,7 @@ impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
         self.len += 1;
     }
 
+    /// Inserts the reference with the given `node_ptr` to the given `position` of the references collection.
     pub fn insert(&mut self, position: usize, node_ptr: NodePtr<V>) {
         for q in (position..self.len).rev() {
             self.array[q + 1] = self.array[q].clone();
@@ -140,6 +141,10 @@ impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
         self.len += 1;
     }
 
+    /// Inserts the reference with the given `node_ptr` just before the given `pivot_ptr` the reference if it exists;
+    /// and returns the position that the new reference is inserted to.
+    ///
+    /// Does nothing leaving the children unchanged if the `pivot_ptr` reference does not exists, and returns None.
     pub fn push_before(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
         self.assert_has_room_for::<1>();
         let position = self.iter().position(|x| x == pivot_ptr);
@@ -149,6 +154,10 @@ impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
         position
     }
 
+    /// Inserts the reference with the given `node_ptr` just after the given `pivot_ptr` the reference if it exists;
+    /// and returns the position that the new reference is inserted to.
+    ///
+    /// Does nothing leaving the children unchanged if the `pivot_ptr` reference does not exists, and returns None.
     pub fn push_after(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
         self.assert_has_room_for::<1>();
         let position = self.iter().position(|x| x == pivot_ptr);

--- a/src/references/array_left_most.rs
+++ b/src/references/array_left_most.rs
@@ -69,6 +69,7 @@ where
         for i in (ref_idx + 1)..self.len {
             self.array[i - 1] = self.array[i].take();
         }
+        self.len -= 1;
     }
 
     #[inline(always)]
@@ -96,11 +97,6 @@ impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
     /// Returns a reference to the node pointer at the `ref_idx` position of the references array.
     pub fn get(&self, ref_idx: usize) -> Option<&NodePtr<V>> {
         self.array[ref_idx].as_ref()
-    }
-
-    /// Returns a mutable reference to the node pointer at the `ref_idx` position of the references array.
-    pub fn get_mut(&mut self, ref_idx: usize) -> Option<&mut NodePtr<V>> {
-        self.array[ref_idx].as_mut()
     }
 
     /// Creates an iterator over node pointers of the references collection.

--- a/src/references/array_left_most.rs
+++ b/src/references/array_left_most.rs
@@ -79,12 +79,14 @@ impl<const N: usize, V: Variant> RefsArrayLeftMost<N, V> {
 
     /// Creates an iterator over node pointers of the references collection.
     pub fn iter(&self) -> ArrayLeftMostPtrIter<V> {
-        ArrayLeftMostPtrIter::new(self.array.iter(), self.len)
+        let slice = &self.array[..self.len];
+        ArrayLeftMostPtrIter::new(slice.iter())
     }
 
     /// Creates a mutable iterator over node pointers of the references collection.
     pub fn iter_mut(&mut self) -> ArrayLeftMostPtrIterMut<V> {
-        ArrayLeftMostPtrIterMut::new(self.array.iter_mut(), self.len)
+        let slice = &mut self.array[..self.len];
+        ArrayLeftMostPtrIterMut::new(slice.iter_mut())
     }
 
     /// Returns whether or not the collection has room for another reference.

--- a/src/references/array_left_most.rs
+++ b/src/references/array_left_most.rs
@@ -41,6 +41,7 @@ impl<const N: usize, V> Refs for RefsArrayLeftMost<N, V>
 where
     V: Variant,
 {
+    #[inline(always)]
     fn empty() -> Self {
         Self {
             array: [const { None }; N],
@@ -48,16 +49,41 @@ where
         }
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.len == 0
     }
 
+    #[inline(always)]
     fn clear(&mut self) {
         self.array
             .iter_mut()
             .take(self.len)
             .for_each(|x| _ = x.take());
         self.len = 0;
+    }
+
+    #[inline(always)]
+    fn remove_at(&mut self, ref_idx: usize) {
+        self.array[ref_idx] = None;
+        for i in (ref_idx + 1)..self.len {
+            self.array[i - 1] = self.array[i].take();
+        }
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, ptr: usize) -> Option<usize> {
+        let x = self.array.iter().enumerate().find(|x| match x.1 {
+            Some(x) => x.ptr() as usize == ptr,
+            None => false,
+        });
+        match x {
+            Some((ref_idx, _)) => {
+                self.remove_at(ref_idx);
+                Some(ref_idx)
+            }
+            None => None,
+        }
     }
 }
 

--- a/src/references/iter/array_left_most_ptr.rs
+++ b/src/references/iter/array_left_most_ptr.rs
@@ -1,0 +1,82 @@
+use crate::{NodePtr, Variant};
+
+/// Iterator for active references of an [`RefsArrayLeftMost`] collection,
+/// which can be created by its `iter` method.
+///
+/// [`RefsArrayLeftMost`]: crate::RefsArrayLeftMost
+pub struct ArrayLeftMostPtrIter<'a, V: Variant> {
+    iter: core::slice::Iter<'a, Option<NodePtr<V>>>,
+    num_nones: usize,
+}
+
+impl<'a, V: Variant> ArrayLeftMostPtrIter<'a, V> {
+    pub(crate) fn new(iter: core::slice::Iter<'a, Option<NodePtr<V>>>, num_somes: usize) -> Self {
+        let num_nones = iter.len() - num_somes;
+        Self { iter, num_nones }
+    }
+}
+
+impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIter<'a, V> {
+    type Item = &'a NodePtr<V>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().and_then(|x| x.as_ref())
+    }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.iter.len() - self.num_nones;
+        (len, Some(len))
+    }
+}
+
+impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIter<'a, V> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.iter.len() - self.num_nones
+    }
+}
+
+// mut
+
+/// Mutable iterator for active references of an [`RefsArrayLeftMost`] collection,
+/// which can be created by its `iter_mut` method.
+///
+/// [`RefsArrayLeftMost`]: crate::RefsArrayLeftMost
+pub struct ArrayLeftMostPtrIterMut<'a, V: Variant> {
+    iter: core::slice::IterMut<'a, Option<NodePtr<V>>>,
+    num_nones: usize,
+}
+
+impl<'a, V: Variant> ArrayLeftMostPtrIterMut<'a, V> {
+    pub(crate) fn new(
+        iter: core::slice::IterMut<'a, Option<NodePtr<V>>>,
+        num_somes: usize,
+    ) -> Self {
+        let num_nones = iter.len() - num_somes;
+        Self { iter, num_nones }
+    }
+}
+
+impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIterMut<'a, V> {
+    type Item = &'a mut NodePtr<V>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().and_then(|x| x.as_mut())
+    }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.iter.len() - self.num_nones;
+        (len, Some(len))
+    }
+}
+
+impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIterMut<'a, V> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.iter.len() - self.num_nones
+    }
+}

--- a/src/references/iter/array_left_most_ptr.rs
+++ b/src/references/iter/array_left_most_ptr.rs
@@ -16,6 +16,15 @@ impl<'a, V: Variant> ArrayLeftMostPtrIter<'a, V> {
     }
 }
 
+impl<'a, V: Variant> Default for ArrayLeftMostPtrIter<'a, V> {
+    fn default() -> Self {
+        Self {
+            iter: Default::default(),
+            num_nones: 0,
+        }
+    }
+}
+
 impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIter<'a, V> {
     type Item = &'a NodePtr<V>;
 
@@ -56,6 +65,15 @@ impl<'a, V: Variant> ArrayLeftMostPtrIterMut<'a, V> {
     ) -> Self {
         let num_nones = iter.len() - num_somes;
         Self { iter, num_nones }
+    }
+}
+
+impl<'a, V: Variant> Default for ArrayLeftMostPtrIterMut<'a, V> {
+    fn default() -> Self {
+        Self {
+            iter: Default::default(),
+            num_nones: 0,
+        }
     }
 }
 

--- a/src/references/iter/array_left_most_ptr.rs
+++ b/src/references/iter/array_left_most_ptr.rs
@@ -14,7 +14,7 @@ impl<'a, V: Variant> ArrayLeftMostPtrIter<'a, V> {
     }
 }
 
-impl<'a, V: Variant> Default for ArrayLeftMostPtrIter<'a, V> {
+impl<V: Variant> Default for ArrayLeftMostPtrIter<'_, V> {
     fn default() -> Self {
         Self {
             iter: Default::default(),
@@ -37,14 +37,14 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIter<'a, V> {
     }
 }
 
-impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIter<'a, V> {
+impl<V: Variant> ExactSizeIterator for ArrayLeftMostPtrIter<'_, V> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-impl<'a, V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIter<'a, V> {
+impl<V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIter<'_, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().and_then(|x| x.as_ref())
     }
@@ -66,7 +66,7 @@ impl<'a, V: Variant> ArrayLeftMostPtrIterMut<'a, V> {
     }
 }
 
-impl<'a, V: Variant> Default for ArrayLeftMostPtrIterMut<'a, V> {
+impl<V: Variant> Default for ArrayLeftMostPtrIterMut<'_, V> {
     fn default() -> Self {
         Self {
             iter: Default::default(),
@@ -89,14 +89,14 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIterMut<'a, V> {
     }
 }
 
-impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIterMut<'a, V> {
+impl<V: Variant> ExactSizeIterator for ArrayLeftMostPtrIterMut<'_, V> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-impl<'a, V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIterMut<'a, V> {
+impl<V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIterMut<'_, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().and_then(|x| x.as_mut())
     }

--- a/src/references/iter/array_left_most_ptr.rs
+++ b/src/references/iter/array_left_most_ptr.rs
@@ -6,13 +6,11 @@ use crate::{NodePtr, Variant};
 /// [`RefsArrayLeftMost`]: crate::RefsArrayLeftMost
 pub struct ArrayLeftMostPtrIter<'a, V: Variant> {
     iter: core::slice::Iter<'a, Option<NodePtr<V>>>,
-    num_nones: usize,
 }
 
 impl<'a, V: Variant> ArrayLeftMostPtrIter<'a, V> {
-    pub(crate) fn new(iter: core::slice::Iter<'a, Option<NodePtr<V>>>, num_somes: usize) -> Self {
-        let num_nones = iter.len() - num_somes;
-        Self { iter, num_nones }
+    pub(crate) fn new(iter: core::slice::Iter<'a, Option<NodePtr<V>>>) -> Self {
+        Self { iter }
     }
 }
 
@@ -20,7 +18,6 @@ impl<'a, V: Variant> Default for ArrayLeftMostPtrIter<'a, V> {
     fn default() -> Self {
         Self {
             iter: Default::default(),
-            num_nones: 0,
         }
     }
 }
@@ -35,7 +32,7 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIter<'a, V> {
 
     #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.iter.len() - self.num_nones;
+        let len = self.iter.len();
         (len, Some(len))
     }
 }
@@ -43,7 +40,7 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIter<'a, V> {
 impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIter<'a, V> {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.iter.len() - self.num_nones
+        self.iter.len()
     }
 }
 
@@ -61,16 +58,11 @@ impl<'a, V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIter<'a, V> {
 /// [`RefsArrayLeftMost`]: crate::RefsArrayLeftMost
 pub struct ArrayLeftMostPtrIterMut<'a, V: Variant> {
     iter: core::slice::IterMut<'a, Option<NodePtr<V>>>,
-    num_nones: usize,
 }
 
 impl<'a, V: Variant> ArrayLeftMostPtrIterMut<'a, V> {
-    pub(crate) fn new(
-        iter: core::slice::IterMut<'a, Option<NodePtr<V>>>,
-        num_somes: usize,
-    ) -> Self {
-        let num_nones = iter.len() - num_somes;
-        Self { iter, num_nones }
+    pub(crate) fn new(iter: core::slice::IterMut<'a, Option<NodePtr<V>>>) -> Self {
+        Self { iter }
     }
 }
 
@@ -78,7 +70,6 @@ impl<'a, V: Variant> Default for ArrayLeftMostPtrIterMut<'a, V> {
     fn default() -> Self {
         Self {
             iter: Default::default(),
-            num_nones: 0,
         }
     }
 }
@@ -93,7 +84,7 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIterMut<'a, V> {
 
     #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.iter.len() - self.num_nones;
+        let len = self.iter.len();
         (len, Some(len))
     }
 }
@@ -101,7 +92,7 @@ impl<'a, V: Variant> Iterator for ArrayLeftMostPtrIterMut<'a, V> {
 impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIterMut<'a, V> {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.iter.len() - self.num_nones
+        self.iter.len()
     }
 }
 

--- a/src/references/iter/array_left_most_ptr.rs
+++ b/src/references/iter/array_left_most_ptr.rs
@@ -47,6 +47,12 @@ impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIter<'a, V> {
     }
 }
 
+impl<'a, V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIter<'a, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().and_then(|x| x.as_ref())
+    }
+}
+
 // mut
 
 /// Mutable iterator for active references of an [`RefsArrayLeftMost`] collection,
@@ -96,5 +102,11 @@ impl<'a, V: Variant> ExactSizeIterator for ArrayLeftMostPtrIterMut<'a, V> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.iter.len() - self.num_nones
+    }
+}
+
+impl<'a, V: Variant> DoubleEndedIterator for ArrayLeftMostPtrIterMut<'a, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().and_then(|x| x.as_mut())
     }
 }

--- a/src/references/iter/mod.rs
+++ b/src/references/iter/mod.rs
@@ -1,0 +1,3 @@
+mod array_left_most_ptr;
+
+pub use array_left_most_ptr::{ArrayLeftMostPtrIter, ArrayLeftMostPtrIterMut};

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -1,3 +1,4 @@
+/// Iterators over node references.
 pub mod iter;
 
 mod array;

--- a/src/references/mod.rs
+++ b/src/references/mod.rs
@@ -1,4 +1,7 @@
+pub mod iter;
+
 mod array;
+mod array_left_most;
 mod node_idx;
 mod node_idx_error;
 mod node_ptr;
@@ -8,6 +11,7 @@ mod single;
 mod vec;
 
 pub use array::RefsArray;
+pub use array_left_most::RefsArrayLeftMost;
 pub use node_idx::NodeIdx;
 pub use node_idx_error::NodeIdxError;
 pub use node_ptr::NodePtr;

--- a/src/references/node_idx.rs
+++ b/src/references/node_idx.rs
@@ -1,6 +1,7 @@
 use super::NodePtr;
-use crate::{MemoryState, Node, Variant};
+use crate::{MemoryPolicy, MemoryState, Node, SelfRefCol, Variant};
 use core::fmt::Debug;
+use orx_pinned_vec::PinnedVec;
 
 /// A node index providing safe and constant time access to elements
 /// of the self referential collection.
@@ -77,5 +78,20 @@ where
     #[inline(always)]
     pub fn node_ptr(&self) -> NodePtr<V> {
         NodePtr::new(self.ptr)
+    }
+
+    /// Returns true only if this index is valid for the given `collection`.
+    ///
+    /// A node index is valid iff it satisfies the following two conditions:
+    ///
+    /// * It is created from the given `collection`.
+    /// * Memory state of the `collection` has not changed since this index was created.
+    #[inline(always)]
+    pub fn is_valid_for<M, P>(&self, collection: &SelfRefCol<V, M, P>) -> bool
+    where
+        M: MemoryPolicy<V>,
+        P: PinnedVec<Node<V>>,
+    {
+        self.state == collection.memory_state() && collection.nodes().contains_ptr(self.ptr)
     }
 }

--- a/src/references/node_idx.rs
+++ b/src/references/node_idx.rs
@@ -45,7 +45,7 @@ where
     #[inline(always)]
     pub fn new(state: MemoryState, node_ptr: &NodePtr<V>) -> Self {
         Self {
-            ptr: node_ptr.ptr(),
+            ptr: node_ptr.ptr_mut(),
             state,
         }
     }

--- a/src/references/node_idx.rs
+++ b/src/references/node_idx.rs
@@ -92,6 +92,8 @@ where
         M: MemoryPolicy<V>,
         P: PinnedVec<Node<V>>,
     {
-        self.state == collection.memory_state() && collection.nodes().contains_ptr(self.ptr)
+        self.state == collection.memory_state()
+            && collection.nodes().contains_ptr(self.ptr)
+            && unsafe { &*self.ptr }.is_active()
     }
 }

--- a/src/references/node_ptr.rs
+++ b/src/references/node_ptr.rs
@@ -34,9 +34,15 @@ impl<V: Variant> NodePtr<V> {
         }
     }
 
-    /// Returns the raw pointer.
+    /// Returns the const raw pointer.
     #[inline(always)]
-    pub fn ptr(&self) -> *mut Node<V> {
+    pub fn ptr(&self) -> *const Node<V> {
+        self.ptr
+    }
+
+    /// Returns the mutable raw pointer.
+    #[inline(always)]
+    pub fn ptr_mut(&self) -> *mut Node<V> {
         self.ptr
     }
 
@@ -63,7 +69,7 @@ impl<V: Variant> NodePtr<V> {
     /// * the collection is still alive, and finally,
     /// * the memory state of the collection has not changed since the pointer was created.
     #[inline]
-    pub unsafe fn node_mut(&mut self) -> &mut Node<V> {
+    pub unsafe fn node_mut(&self) -> &mut Node<V> {
         &mut *self.ptr
     }
 }

--- a/src/references/none.rs
+++ b/src/references/none.rs
@@ -5,13 +5,24 @@ use super::refs::Refs;
 pub struct RefsNone;
 
 impl Refs for RefsNone {
+    #[inline(always)]
     fn empty() -> Self {
         Self
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         true
     }
 
+    #[inline(always)]
     fn clear(&mut self) {}
+
+    #[inline(always)]
+    fn remove_at(&mut self, _: usize) {}
+
+    #[inline(always)]
+    fn remove(&mut self, _: usize) -> Option<usize> {
+        None
+    }
 }

--- a/src/references/refs.rs
+++ b/src/references/refs.rs
@@ -10,4 +10,12 @@ pub trait Refs: Clone + Debug {
 
     /// Clears the references.
     fn clear(&mut self);
+
+    /// Removes the reference at the given `ref_idx`.
+    fn remove_at(&mut self, ref_idx: usize);
+
+    /// Removes the node reference from references pointing to the node at given `ptr` location.
+    ///
+    /// Returns the position of the `ptr` among references if it exists; None otherwise.
+    fn remove(&mut self, ptr: usize) -> Option<usize>;
 }

--- a/src/references/single.rs
+++ b/src/references/single.rs
@@ -20,16 +20,43 @@ impl<V: Variant> Debug for RefsSingle<V> {
 }
 
 impl<V: Variant> Refs for RefsSingle<V> {
+    #[inline(always)]
     fn empty() -> Self {
         Self(None)
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.0.is_none()
     }
 
+    #[inline(always)]
     fn clear(&mut self) {
         _ = self.0.take();
+    }
+
+    #[inline(always)]
+    fn remove_at(&mut self, ref_idx: usize) {
+        assert_eq!(
+            ref_idx, 0,
+            "Reference idx {} is out of bounds for RefsSingle.",
+            ref_idx
+        );
+        self.clear();
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, ptr: usize) -> Option<usize> {
+        match &mut self.0 {
+            None => None,
+            Some(x) => match x.ptr() as usize == ptr {
+                true => {
+                    self.clear();
+                    Some(0)
+                }
+                false => None,
+            },
+        }
     }
 }
 

--- a/src/references/single.rs
+++ b/src/references/single.rs
@@ -35,8 +35,8 @@ impl<V: Variant> Refs for RefsSingle<V> {
 
 impl<V: Variant> RefsSingle<V> {
     /// Returns the pointer to the referenced node.
-    pub fn get(&self) -> Option<NodePtr<V>> {
-        self.0.clone()
+    pub fn get(&self) -> Option<&NodePtr<V>> {
+        self.0.as_ref()
     }
 
     /// Sets the pointer to the referenced node with the given `node_idx`.
@@ -45,8 +45,8 @@ impl<V: Variant> RefsSingle<V> {
     }
 
     /// Sets the pointer to the referenced node with the given `node_idx`.
-    pub fn set_some(&mut self, node_idx: &NodePtr<V>) {
-        self.0 = Some(node_idx.clone())
+    pub fn set_some(&mut self, node_idx: NodePtr<V>) {
+        self.0 = Some(node_idx)
     }
 
     /// Un-sets the reference.

--- a/src/references/vec.rs
+++ b/src/references/vec.rs
@@ -21,16 +21,40 @@ impl<V: Variant> Debug for RefsVec<V> {
 }
 
 impl<V: Variant> Refs for RefsVec<V> {
+    #[inline(always)]
     fn empty() -> Self {
         Self(Vec::new())
     }
 
+    #[inline(always)]
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    #[inline(always)]
     fn clear(&mut self) {
         self.0.clear();
+    }
+
+    #[inline(always)]
+    fn remove_at(&mut self, ref_idx: usize) {
+        self.0.remove(ref_idx);
+    }
+
+    #[inline(always)]
+    fn remove(&mut self, ptr: usize) -> Option<usize> {
+        let x = self
+            .0
+            .iter()
+            .enumerate()
+            .find(|x| x.1.ptr() as usize == ptr);
+        match x {
+            Some((ref_idx, _)) => {
+                self.0.remove(ref_idx);
+                Some(ref_idx)
+            }
+            None => None,
+        }
     }
 }
 

--- a/src/references/vec.rs
+++ b/src/references/vec.rs
@@ -89,10 +89,15 @@ impl<V: Variant> RefsVec<V> {
         self.0.push(node_ptr);
     }
 
+    /// Inserts the reference with the given `node_ptr` to the given `position` of the references collection.
     pub fn insert(&mut self, position: usize, node_ptr: NodePtr<V>) {
         self.0.insert(position, node_ptr);
     }
 
+    /// Inserts the reference with the given `node_ptr` just before the given `pivot_ptr` the reference if it exists;
+    /// and returns the position that the new reference is inserted to.
+    ///
+    /// Does nothing leaving the children unchanged if the `pivot_ptr` reference does not exists, and returns None.
     pub fn push_before(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
         let position = self.iter().position(|x| x == pivot_ptr);
         if let Some(p) = position {
@@ -101,6 +106,10 @@ impl<V: Variant> RefsVec<V> {
         position
     }
 
+    /// Inserts the reference with the given `node_ptr` just after the given `pivot_ptr` the reference if it exists;
+    /// and returns the position that the new reference is inserted to.
+    ///
+    /// Does nothing leaving the children unchanged if the `pivot_ptr` reference does not exists, and returns None.
     pub fn push_after(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
         let position = self.iter().position(|x| x == pivot_ptr);
         if let Some(p) = position {

--- a/src/references/vec.rs
+++ b/src/references/vec.rs
@@ -33,3 +33,30 @@ impl<V: Variant> Refs for RefsVec<V> {
         self.0.clear();
     }
 }
+
+impl<V: Variant> RefsVec<V> {
+    /// Returns the number of references.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the i-th node pointer; None if out of bounds.
+    pub fn get(&self, i: usize) -> Option<&NodePtr<V>> {
+        self.0.get(i)
+    }
+
+    /// Creates an iterator over node pointers of the references collection.
+    pub fn iter(&self) -> core::slice::Iter<NodePtr<V>> {
+        self.0.iter()
+    }
+
+    /// Creates a mutable iterator over node pointers of the references collection.
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<NodePtr<V>> {
+        self.0.iter_mut()
+    }
+
+    /// Pushes the node references to the end of the references collection.
+    pub fn push(&mut self, node_ptr: NodePtr<V>) {
+        self.0.push(node_ptr);
+    }
+}

--- a/src/references/vec.rs
+++ b/src/references/vec.rs
@@ -64,6 +64,11 @@ impl<V: Variant> RefsVec<V> {
         self.0.len()
     }
 
+    /// Returns true if the number of references is zero.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Returns the i-th node pointer; None if out of bounds.
     pub fn get(&self, i: usize) -> Option<&NodePtr<V>> {
         self.0.get(i)
@@ -82,5 +87,41 @@ impl<V: Variant> RefsVec<V> {
     /// Pushes the node references to the end of the references collection.
     pub fn push(&mut self, node_ptr: NodePtr<V>) {
         self.0.push(node_ptr);
+    }
+
+    pub fn insert(&mut self, position: usize, node_ptr: NodePtr<V>) {
+        self.0.insert(position, node_ptr);
+    }
+
+    pub fn push_before(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
+        let position = self.iter().position(|x| x == pivot_ptr);
+        if let Some(p) = position {
+            self.0.insert(p, node_ptr);
+        }
+        position
+    }
+
+    pub fn push_after(&mut self, pivot_ptr: &NodePtr<V>, node_ptr: NodePtr<V>) -> Option<usize> {
+        let position = self.iter().position(|x| x == pivot_ptr);
+        if let Some(p) = position {
+            self.0.insert(p + 1, node_ptr);
+        }
+        position
+    }
+
+    /// Replaces the node reference `old_node_ptr` with the `new_node_ptr` and returns
+    /// the position of the reference.
+    ///
+    /// Does nothing and returns None if the `old_node_ptr` is absent.
+    pub fn replace_with(
+        &mut self,
+        old_node_ptr: &NodePtr<V>,
+        new_node_ptr: NodePtr<V>,
+    ) -> Option<usize> {
+        let position = self.0.iter().position(|x| x == old_node_ptr);
+        if let Some(p) = position {
+            self.0[p] = new_node_ptr;
+        }
+        position
     }
 }

--- a/src/selfref_col.rs
+++ b/src/selfref_col.rs
@@ -114,6 +114,16 @@ where
         data
     }
 
+    /// Succeeding the operation of closing of node with the given `node_ptr`,
+    /// reclaims closed nodes if necessary.
+    ///
+    /// Returns whether the memory state changed.
+    pub fn reclaim_from_closed_node(&mut self, node_ptr: &NodePtr<V>) -> bool {
+        let state_changed = M::reclaim_closed_nodes(self, node_ptr);
+        self.update_state(state_changed);
+        state_changed
+    }
+
     /// If `state_changed` is true, proceeds to the next memory state.
     #[inline(always)]
     pub fn update_state(&mut self, state_changed: bool) {

--- a/src/selfref_col.rs
+++ b/src/selfref_col.rs
@@ -164,6 +164,25 @@ where
         }
     }
 
+    /// Tries to get a valid pointer to the node with the given `NodeIdx`;
+    /// returns None if the index is invalid.
+    #[inline(always)]
+    pub fn get_ptr(&self, idx: &NodeIdx<V>) -> Option<NodePtr<V>> {
+        match self.nodes().contains_ptr(idx.ptr()) {
+            true => match idx.is_in_state(self.state) {
+                true => {
+                    let ptr = idx.ptr();
+                    match unsafe { &*ptr }.is_active() {
+                        true => Some(NodePtr::new(ptr)),
+                        false => None,
+                    }
+                }
+                false => None,
+            },
+            false => None,
+        }
+    }
+
     // mut
 
     /// Clears the collection and changes the memory state.
@@ -196,5 +215,11 @@ where
             },
             false => Err(NodeIdxError::OutOfBounds),
         }
+    }
+
+    /// Pushes the element with the given `data` and returns its index.
+    pub fn push_get_idx(&mut self, data: V::Item) -> NodeIdx<V> {
+        let node_ptr = self.push(data);
+        NodeIdx::new(self.memory_state(), &node_ptr)
     }
 }

--- a/src/selfref_col.rs
+++ b/src/selfref_col.rs
@@ -155,6 +155,19 @@ where
         }
     }
 
+    /// Returns the node index error if the index is invalid.
+    /// Returns None if it is valid.
+    #[inline(always)]
+    pub fn node_idx_error(&self, idx: &NodeIdx<V>) -> Option<NodeIdxError> {
+        match self.try_node_from_idx(idx) {
+            Ok(node) => match node.is_active() {
+                true => None,
+                false => Some(NodeIdxError::RemovedNode),
+            },
+            Err(err) => Some(err),
+        }
+    }
+
     /// Tries to get a valid pointer to the node with the given `NodeIdx`;
     /// returns the error if the index is invalid.
     #[inline(always)]

--- a/tests/doubly_linked_list.rs
+++ b/tests/doubly_linked_list.rs
@@ -42,21 +42,21 @@ where
     let new_idx = col.node_ptr_at_pos(vacant);
     let old_idx = col.node_ptr_at_pos(occupied);
 
-    if let Some(prev) = col.nodes()[occupied].prev().get() {
+    if let Some(prev) = col.nodes()[occupied].prev().get().cloned() {
         col.node_mut(&prev).next_mut().set(Some(new_idx.clone()));
     }
 
-    if let Some(next) = col.nodes()[occupied].next().get() {
+    if let Some(next) = col.nodes()[occupied].next().get().cloned() {
         col.node_mut(&next).prev_mut().set(Some(new_idx.clone()));
     }
 
     col.move_node(vacant, occupied);
 
-    if old_idx == col.ends().get(0).expect("nonempty list") {
+    if old_idx == col.ends().get(0).cloned().expect("nonempty list") {
         col.ends_mut().set(0, Some(new_idx.clone()));
     }
 
-    if old_idx == col.ends().get(1).expect("nonempty list") {
+    if old_idx == col.ends().get(1).cloned().expect("nonempty list") {
         col.ends_mut().set(1, Some(new_idx));
     }
 }
@@ -127,14 +127,14 @@ fn front<M>(col: &Col<String, M>) -> Option<NodePtr<Doubly<String>>>
 where
     M: MemoryPolicy<Doubly<String>>,
 {
-    col.ends().get(0)
+    col.ends().get(0).cloned()
 }
 
 fn back<M>(col: &Col<String, M>) -> Option<NodePtr<Doubly<String>>>
 where
     M: MemoryPolicy<Doubly<String>>,
 {
-    col.ends().get(1)
+    col.ends().get(1).cloned()
 }
 
 fn front_back<M>(col: &Col<String, M>) -> [&Node<Doubly<String>>; 2]
@@ -157,7 +157,12 @@ where
         x if x < half_len => {
             let mut current = front(col).expect("non-empty list");
             for _ in 0..at {
-                current = col.node(&current).next().get().expect("must exist");
+                current = col
+                    .node(&current)
+                    .next()
+                    .get()
+                    .cloned()
+                    .expect("must exist");
             }
             Some(current)
         }
@@ -165,7 +170,12 @@ where
             let mut current = back(col).expect("non-empty list");
             let num_jumps = len - at - 1;
             for _ in 0..num_jumps {
-                current = col.node(&current).prev().get().expect("must exist");
+                current = col
+                    .node(&current)
+                    .prev()
+                    .get()
+                    .cloned()
+                    .expect("must exist");
             }
             Some(current)
         }
@@ -187,7 +197,7 @@ where
     M: MemoryPolicy<Doubly<String>>,
 {
     let idx = col.push(value);
-    let old_front = col.ends().get(0).unwrap();
+    let old_front = col.ends().get(0).cloned().unwrap();
 
     col.node_mut(&idx).next_mut().set(Some(old_front.clone()));
     col.node_mut(&old_front).prev_mut().set(Some(idx.clone()));
@@ -199,7 +209,7 @@ where
     M: MemoryPolicy<Doubly<String>>,
 {
     let idx = col.push(value);
-    let old_back = col.ends().get(1).unwrap();
+    let old_back = col.ends().get(1).cloned().unwrap();
 
     col.node_mut(&idx).prev_mut().set(Some(old_back.clone()));
     col.node_mut(&old_back).next_mut().set(Some(idx.clone()));
@@ -210,8 +220,8 @@ fn pop_front<M>(col: &mut Col<String, M>) -> Option<String>
 where
     M: MemoryPolicy<Doubly<String>>,
 {
-    col.ends().get(0).map(|front_idx| {
-        match col.node(&front_idx).next().get() {
+    col.ends().get(0).cloned().map(|front_idx| {
+        match col.node(&front_idx).next().get().cloned() {
             Some(new_front) => {
                 col.node_mut(&new_front).prev_mut().clear();
                 col.ends_mut().set(0, Some(new_front));
@@ -227,8 +237,8 @@ fn pop_back<M>(col: &mut Col<String, M>) -> Option<String>
 where
     M: MemoryPolicy<Doubly<String>>,
 {
-    col.ends().get(1).map(|back_idx| {
-        match col.node(&back_idx).prev().get() {
+    col.ends().get(1).cloned().map(|back_idx| {
+        match col.node(&back_idx).prev().get().cloned() {
             Some(new_back) => {
                 col.node_mut(&new_back).next_mut().clear();
                 col.ends_mut().set(1, Some(new_back));
@@ -251,7 +261,7 @@ where
 
                 let [prev, next] = {
                     let node = col.node(&node_idx);
-                    [node.prev().get(), node.next().get()]
+                    [node.prev().get().cloned(), node.next().get().cloned()]
                 };
 
                 match prev {

--- a/tests/singly_linked_list.rs
+++ b/tests/singly_linked_list.rs
@@ -18,7 +18,7 @@ impl<T> MemoryReclaimer<Singly<T>> for OnThresholdReclaimer {
     {
         let mut nodes_moved = false;
 
-        if let Some(mut current) = col.ends().get() {
+        if let Some(mut current) = col.ends().get().cloned() {
             let mut prev = None;
 
             for vacant in 0..col.nodes().len() {
@@ -36,7 +36,7 @@ impl<T> MemoryReclaimer<Singly<T>> for OnThresholdReclaimer {
                         swap(col, vacant, occupied, prev);
                     }
 
-                    match col.node(&current).next().get() {
+                    match col.node(&current).next().get().cloned() {
                         Some(next) => {
                             prev = Some(occupied);
                             current = next;
@@ -122,7 +122,7 @@ where
 {
     let idx = col.push(value);
 
-    if let Some(old_front) = col.ends().get() {
+    if let Some(old_front) = col.ends().get().cloned() {
         col.node_mut(&idx).next_mut().set(Some(old_front));
     }
 
@@ -135,8 +135,8 @@ fn pop_front<M>(col: &mut Col<String, M>) -> Option<String>
 where
     M: MemoryPolicy<Singly<String>>,
 {
-    col.ends().get().map(|front_idx| {
-        match col.node(&front_idx).next().get() {
+    col.ends().get().cloned().map(|front_idx| {
+        match col.node(&front_idx).next().get().cloned() {
             Some(new_front) => col.ends_mut().set(Some(new_front)),
             None => col.ends_mut().clear(),
         }


### PR DESCRIPTION
Public api is extended to support self referential tree data structures.

`RefsArrayLeftMost` reference collection is added. This is a constant size array of optional references which acts like a dynamic size vector.

Reference collection update methods are extended.
